### PR TITLE
Add Business & Operations section with three learning paths

### DIFF
--- a/content/business/index.md
+++ b/content/business/index.md
@@ -1,0 +1,88 @@
+---
+title: Business & Operations
+tags:
+  - business
+  - operations
+  - learning-path
+draft: false
+---
+
+# Business & Operations
+
+Build the skills to run a modern IT organisation — not just the technical stack, but the operational systems, documentation practices, and client knowledge management that make teams scalable and professional.
+
+These paths complement the technical learning paths. An IT professional who can also structure a business, document effectively, and manage client knowledge is far more valuable than one who can only configure systems.
+
+## 📚 Learning Paths
+
+### 🚀 [Startups Playbook](/business/startups-playbook)
+
+**Build your startup's tech stack with open-source tools.**
+
+From choosing your Business Operating System to scaling infrastructure, this path covers the decisions that determine whether a startup controls its own destiny or becomes hostage to vendor lock-in. AU-focused, opinionated, and practical.
+
+- Infrastructure decisions (Proxmox, Docker, K8s)
+- Security & identity from day one (Keycloak, NetBird)
+- Business operations stack (ERPNext, n8n, CRM)
+- Legal & compliance (ISMS, Privacy Act, AU-specific)
+
+---
+
+### 📋 [MSP Content Model](/business/msp-content-model)
+
+**Structure knowledge for scalable IT service delivery.**
+
+Knowledge silos kill MSPs. This path teaches you how to inventory your information types, map relationships between them, establish governance, and implement a content model that survives staff turnover and scales with the business.
+
+- Information inventory and template anatomy
+- Relationship mapping with Mermaid diagrams
+- Governance roles and review cycles
+- Phased rollout from pilot to institutionalisation
+
+---
+
+### 📝 [PIMPyourDocs](/business/pimpyourdocs)
+
+**Own your documentation with plain-text-first practices.**
+
+Documentation that lives in a vendor's cloud is documentation you don't own. This path teaches the philosophy and practice of plain-text, git-versioned, AI-ready documentation — including Mermaid diagrams, ADR templates, runbooks, and escape routes from Confluence and Notion.
+
+- Markdown and git as documentation infrastructure
+- Mermaid diagrams as code (flowchart, sequence, ER, state)
+- Professional templates (ADR, RUNBOOK, SERVICE, API, INCIDENT)
+- Migration guides for Confluence, Notion, and Google Docs
+
+---
+
+## 🔗 How These Paths Connect
+
+```
+Startups Playbook ──► sets the infra and ops context
+        │
+        ▼
+MSP Content Model ──► structures the knowledge inside that infra
+        │
+        ▼
+PIMPyourDocs ──────► provides the documentation layer for all of it
+```
+
+All three paths connect back to TWN Systems providers and tools. As you work through them, you'll see how digital sovereignty applies not just to networking and servers, but to business operations.
+
+---
+
+> [!TIP] Need guidance?
+> Join the [TWN Commons on Discord](https://discord.gg/kgaMm6WJya) to ask questions, share progress, and connect with other learners and practitioners.
+
+> [!NOTE] Bridge to TWN Systems
+> The tools and practices in these paths are how TWN itself operates. Explore [TWN Systems](https://twn.systems) to find providers and tools that align with these principles.
+
+---
+
+## 🔄 Connect to Technical Paths
+
+These business paths build on and connect to the technical learning paths:
+
+- **[Networking Fundamentals](/paths/networking)** — Understand the infrastructure these businesses run on
+- **[Linux Systems](/paths/linux)** — Operate the servers hosting these open-source tools
+- **[VyOS and Proxmox Network Infrastructure](/paths/vyos-proxmox)** — The infra stack the Startups Playbook recommends
+- **[NetBird VPN](/paths/netbird-vpn)** — Zero-trust networking for the security milestone

--- a/content/business/msp-content-model.md
+++ b/content/business/msp-content-model.md
@@ -1,0 +1,267 @@
+---
+title: MSP Content Model
+tags:
+  - msp
+  - knowledge-management
+  - documentation
+  - learning-path
+draft: false
+---
+
+# MSP Content Model Learning Path
+
+Structure your knowledge so your business survives staff turnover, scales with new clients, and stops depending on what lives in one person's head. This path takes you from scattered tribal knowledge to a governed, repeatable content model that makes your MSP professionally scalable.
+
+## 📋 Overview
+
+**Duration:** 4–6 weeks (self-paced)
+**Level:** Intermediate
+**Prerequisites:** Basic understanding of IT service delivery, familiarity with any documentation tool
+
+**Why this matters:** Knowledge silos are the silent killer of MSPs. When the person who "knows everything about Client X" leaves, you lose months of context. When a new technician onboards, they drown in undocumented processes. A content model solves this by treating knowledge as a structured, governed asset — not a personal document collection.
+
+## ✅ Prerequisites
+
+Before starting this path, you should:
+- [ ] Work in or understand an IT service delivery context (MSP, internal IT team, or similar)
+- [ ] Have basic familiarity with Markdown or any structured documentation format
+- [ ] Understand the difference between a process and a procedure
+- [ ] **Recommended:** Complete the [PIMPyourDocs](/business/pimpyourdocs) path (or do them in parallel)
+
+## 🎯 Learning Milestones
+
+### 🧠 Milestone 1: Why Content Models Matter (Week 1)
+
+**Goal:** Understand the knowledge management problem MSPs face and why a structured content model is the solution.
+
+**Core Concepts:**
+- The tribal knowledge problem: why "it's in [person's] head" is a business risk
+- Knowledge silos vs. knowledge systems: the difference between storing information and making it findable and usable
+- Information types in an MSP: what kinds of knowledge exist (client configs, runbooks, procedures, onboarding, sales content)
+- The scalability ceiling: how unstructured knowledge limits growth
+- Content model basics: what a content model is (a structured framework for organising information types and their relationships)
+- Why existing tools (SharePoint, Confluence, random folders) fail without a model
+
+**🛠️ Hands-on Practice:**
+- [ ] Audit your current documentation: list every place information is stored in your organisation
+- [ ] Identify 5 examples of tribal knowledge that would be lost if a key person left
+- [ ] Interview a colleague about a recent incident where missing documentation caused a problem
+- [ ] Read the [MSP Content Model README](https://gitlab.tas.twn.network/twn/marketing/msp-content-model) for the framework overview
+
+**Checkpoint:** What's the difference between a document and an information type? Why does that distinction matter when building a content model?
+
+> [!TIP] Need guidance?
+> Join [TWN Commons on Discord](https://discord.gg/kgaMm6WJya) to discuss knowledge management challenges with other IT professionals.
+
+**💬 Share Your Progress:** Post your documentation audit findings in `#knowledge-mgmt` — others will recognise the patterns!
+
+---
+
+### 📋 Milestone 2: Information Inventory (Week 1–2)
+
+**Goal:** Identify and categorise all the information types your MSP creates, uses, and maintains.
+
+**Core Concepts:**
+- Information type vs. document: a "Client Overview" is an information type; a specific client's overview is an instance
+- MSP-specific information types: CLIENT_OVERVIEW, CLIENT_ONBOARDING, RUNBOOK, SERVICE_CATALOGUE, INCIDENT_REPORT, CHANGE_REQUEST, CONTRACT
+- Template anatomy: what every template needs (metadata, required fields, optional fields, lifecycle state)
+- Frontmatter as structured metadata: using YAML frontmatter to make documents machine-readable
+- Information lifecycle: draft → active → archived → deprecated
+- The completeness trap: not every document needs every field — design for the minimum viable structure
+
+**🛠️ Hands-on Practice:**
+- [ ] List every type of document your team creates or uses (not instances — types)
+- [ ] For each type, define: what triggers its creation, who creates it, who uses it, when it's updated, when it's retired
+- [ ] Download and review the MSP Content Model templates (CLIENT_ONBOARDING.md, CLIENT_OVERVIEW.md)
+- [ ] Create an information inventory spreadsheet with columns: Type, Trigger, Creator, Consumer, Update Frequency, Lifecycle
+- [ ] Write a template for one information type that doesn't yet exist in your organisation
+
+**Checkpoint:** What's the purpose of a lifecycle state field in a document template? Give an example of why it matters in an MSP context.
+
+> [!TIP] Stuck on categorisation?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#knowledge-mgmt` channel has practitioners who've done this inventory exercise — share your list and get feedback.
+
+**💬 Share Your Work:** Post your information inventory for peer review in Discord!
+
+---
+
+### 🔗 Milestone 3: Relationship Mapping (Weeks 2–3)
+
+**Goal:** Understand how information types connect to each other and visualise those relationships using Mermaid diagrams.
+
+**Core Concepts:**
+- Information relationships: how a CLIENT_OVERVIEW links to RUNBOOKS, which link to INCIDENTS, which link to CHANGE_REQUESTS
+- Entity-relationship thinking: treating information types like database tables with defined relationships
+- Mermaid diagrams: using `graph` and `erDiagram` syntax to visualise content models
+- Hub documents vs. leaf documents: some information types are entry points (CLIENT_OVERVIEW); others are referenced by many (RUNBOOK)
+- Navigability: a content model only works if users can find information by traversing relationships
+- The orphan problem: documents with no relationships are documents no one will find
+
+**🛠️ Hands-on Practice:**
+- [ ] Draw a relationship diagram (on paper or in Mermaid) showing how your information types connect
+- [ ] Identify which types are "hubs" (many connections) and which are "leaves" (few connections)
+- [ ] Write a Mermaid `erDiagram` for your MSP's core information types
+- [ ] Add relationship fields to three of your templates (e.g., CLIENT_OVERVIEW → related RUNBOOKS)
+- [ ] Find and document 3 orphan documents in your current system and decide what to do with them
+
+**Checkpoint:** Draw the relationship between CLIENT_OVERVIEW, RUNBOOK, and INCIDENT_REPORT. What information flows in each direction?
+
+> [!TIP] Mermaid help?
+> See the [PIMPyourDocs path](/business/pimpyourdocs) Milestone 3 for a full Mermaid tutorial. Join [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` for hands-on help.
+
+**💬 Share Your Work:** Post your Mermaid relationship diagram in Discord for feedback!
+
+---
+
+### 👥 Milestone 4: Governance & Ownership (Weeks 3–4)
+
+**Goal:** Establish who is responsible for each information type, how it gets reviewed, and what happens when it goes stale.
+
+**Core Concepts:**
+- Governance roles: Creator (writes it), Owner (accountable for accuracy), Reviewer (validates on schedule), Consumer (uses it)
+- Review cycles: different information types need different review frequencies (runbooks quarterly, client overviews monthly, contracts at renewal)
+- The stale document problem: undated, unowned documents are worse than no documents
+- Escalation paths: what happens when an owner leaves, or a review is missed
+- Governance without bureaucracy: lightweight processes that actually get followed vs. heavy processes that get ignored
+- Metrics for governance: how do you know your content model is working?
+
+**🛠️ Hands-on Practice:**
+- [ ] Assign a Creator, Owner, and Reviewer role to each information type in your inventory
+- [ ] Define a review cycle for each type (weekly / monthly / quarterly / at-event)
+- [ ] Set up a simple review calendar or recurring reminders for your most critical information types
+- [ ] Write a one-page "Content Governance Policy" covering: roles, review cycles, escalation, and what "stale" means
+- [ ] Audit 10 existing documents and assign owners — note how many have no obvious owner
+
+**Checkpoint:** What's the difference between an Owner and a Reviewer? Why do you need both?
+
+> [!TIP] Governance questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) to discuss what governance looks like in practice — theory is easy, implementation is hard.
+
+**💬 Share Your Progress:** Share your Content Governance Policy draft for peer review!
+
+---
+
+### 🚀 Milestone 5: Implementation (Weeks 4–5)
+
+**Goal:** Roll out your content model in phases — from pilot to full adoption — and measure whether it's working.
+
+**Core Concepts:**
+- Phased rollout: pilot (one team or one client) → expand (broader adoption) → institutionalise (policy and process)
+- Pilot selection: choose a team or client where success is achievable and visible
+- Change management: why people resist new documentation practices and how to address it
+- Quick wins: find documents that are actively painful right now and migrate them first
+- Migration strategy: don't try to migrate everything at once — prioritise by pain and frequency of use
+- Success metrics: document freshness %, orphan rate, time-to-find, onboarding time for new staff
+- Failure modes: the "we'll do it later" trap, the "perfect template" trap, the "no one updates it" trap
+
+**🛠️ Hands-on Practice:**
+- [ ] Select a pilot scope: one client, one service line, or one team
+- [ ] Migrate 10 existing documents into your new templates
+- [ ] Run a "documentation sprint" with your team: block 2 hours to migrate the highest-priority documents
+- [ ] Measure baseline metrics before rollout: how long does it take to find a specific piece of information?
+- [ ] After 2 weeks of pilot, measure again and document what improved
+
+**Checkpoint:** Your pilot is running. Two people say the new templates "take too long to fill in." How do you respond?
+
+> [!TIP] Rollout challenges?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#knowledge-mgmt` channel has people who've done this — share what's working and what isn't.
+
+**💬 Share Your Progress:** Post your pilot results and metrics in Discord!
+
+---
+
+### 🛠️ Milestone 6: Tooling Selection (Weeks 5–6)
+
+**Goal:** Choose the right platform for your content model based on your team's workflow, technical capability, and long-term ownership requirements.
+
+**Core Concepts:**
+- Git-based documentation: Markdown in GitLab/GitHub as the most sovereign and durable option
+- PSA-native documentation: using your existing PSA (ConnectWise, Autotask, HaloPSA) for client-facing docs
+- Wiki platforms: Confluence, Notion, BookStack, Wiki.js — tradeoffs for MSP use
+- The migration risk: getting locked into a platform that makes export painful
+- Tooling criteria: searchability, versioning, access control, export options, cost at scale
+- Hybrid approaches: git for internal docs, PSA for client-facing, and how to keep them in sync
+- When to migrate: signs your current tool is hurting you more than helping
+
+**🛠️ Hands-on Practice:**
+- [ ] Evaluate your current documentation platform against 5 criteria: versioning, export, search, access control, cost
+- [ ] Deploy a self-hosted wiki (BookStack or Wiki.js) and migrate 5 documents into it
+- [ ] Set up a GitLab repository as a documentation store and commit 3 templates as Markdown files
+- [ ] Write a "platform selection" document for your organisation covering: current state, requirements, options evaluated, recommendation
+
+**Checkpoint:** Your MSP is growing and your current wiki is becoming a bottleneck. What criteria would you use to decide whether to migrate vs. fix your current approach?
+
+> [!TIP] Platform questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) to compare notes on documentation platforms — there's experience with all of them.
+
+**💬 Share Your Work:** Share your platform evaluation document for peer feedback!
+
+---
+
+## 📚 Essential Resources
+
+### Documentation
+- [MSP Content Model (TWN)](https://gitlab.tas.twn.network/twn/marketing/msp-content-model) - The source framework this path is based on
+- [BookStack Documentation](https://www.bookstackapp.com/docs/) - Self-hosted wiki platform
+- [Wiki.js Documentation](https://js.wiki) - Modern self-hosted wiki
+- [HaloPSA Knowledge Base](https://halopsa.com) - PSA with built-in documentation features
+
+### Tools and Software
+- **BookStack** - Self-hosted wiki with book/chapter/page structure that maps well to content models
+- **Wiki.js** - Modern, self-hosted wiki with Markdown and Git sync
+- **GitLab** - Git-based documentation with merge request review workflows
+- **Obsidian** - Local Markdown editor with excellent relationship visualisation (good for building the model before committing to a platform)
+- **Mermaid** - Diagram-as-code for relationship maps (see [PIMPyourDocs](/business/pimpyourdocs))
+
+### Practice Labs
+- **Home Lab** - Deploy BookStack or Wiki.js on a small VPS or local VM
+- **GitLab.com** - Free tier sufficient for documentation repositories during learning
+
+## 🤝 Community and Support
+
+**[Join TWN Commons](https://discord.gg/kgaMm6WJya)** for help with:
+- **#knowledge-mgmt** - Content model design, governance, and implementation
+- **#documentation** - Platform selection and migration questions
+- **#msp-ops** - MSP-specific operational challenges
+- **#lab-help** - Assistance with tool deployments
+
+**Share your progress:**
+- Post your information inventory and relationship diagrams
+- Share governance policies for peer review
+- Help others who are earlier in the path
+
+## 🌉 Bridge to TWN Systems
+
+The knowledge management practices in this path are how TWN operates internally:
+
+> [!NOTE] Bridge to TWN
+> TWN's MSP operations use the same content model framework taught here. Explore [TWN Systems](https://twn.systems) to find:
+> - **MSP portal tools** (twnpanel.com and OpenSelfService) that integrate with structured documentation
+> - **Self-hosted wiki providers** who support TWN-aligned hosting
+> - **Community-vetted templates** refined through real MSP use
+
+**🛠️ Connected Paths:**
+- **[PIMPyourDocs](/business/pimpyourdocs)** - The documentation layer and tooling philosophy that underpins this content model
+- **[Startups Playbook](/business/startups-playbook)** - The broader business operations context where this knowledge model lives
+
+## 🚀 What's Next?
+
+After completing this path, you'll be ready for:
+- **[PIMPyourDocs](/business/pimpyourdocs)** - Deepen the documentation layer with plain-text-first practices
+- **[Startups Playbook](/business/startups-playbook)** - Apply knowledge management to a broader business operating system
+- **[Linux Systems](/paths/linux)** - Self-host the wiki platform your content model runs on
+- **Advanced MSP Operations** - Deeper dives into PSA configuration, client lifecycle management, and service catalogue design
+
+## 🏆 Certification Alignment
+
+This learning path provides practical grounding for:
+- **ITIL Foundation** - Service management and knowledge management align directly with ITIL v4 practices
+- **CompTIA Project+** - Project and change management concepts from the governance milestone
+- **Microsoft 365 Certified: Fundamentals** - If your MSP is Microsoft-stack heavy, the information typing skills transfer
+
+> [!TIP] Focus on Understanding, Not Certs
+> A content model that actually gets used is worth more than any certification. Build the practice first.
+
+---
+
+**Ready to start?** Begin with Milestone 1 and join the [TWN Commons #knowledge-mgmt channel](https://discord.gg/kgaMm6WJya) for support and community.

--- a/content/business/pimpyourdocs.md
+++ b/content/business/pimpyourdocs.md
@@ -1,0 +1,277 @@
+---
+title: PIMPyourDocs
+tags:
+  - documentation
+  - markdown
+  - plain-text
+  - learning-path
+draft: false
+---
+
+# PIMPyourDocs Learning Path
+
+Documentation you don't own is documentation that can disappear. This path teaches the philosophy and practice of plain-text, git-versioned, AI-ready documentation — from Markdown fundamentals to professional templates, Mermaid diagrams, and clean migration paths away from Confluence, Notion, and Google Docs.
+
+## 📋 Overview
+
+**Duration:** 4–6 weeks (self-paced)
+**Level:** Beginner to Intermediate
+**Prerequisites:** Basic text editing, familiarity with any file system
+
+**Why this matters:** Most teams write documentation into someone else's platform: Confluence (Atlassian owns your content), Notion (proprietary export), Google Docs (requires Google account to access). When the platform changes pricing, gets acquired, or sunsets, your documentation becomes a migration crisis. Plain-text Markdown with git version control is the antidote — it's readable by humans, processable by machines, versionable with git, and exportable to anything.
+
+## ✅ Prerequisites
+
+Before starting this path, you should:
+- [ ] Be comfortable opening and editing text files
+- [ ] Understand what a file system is (folders, files, paths)
+- [ ] Have git installed (or be willing to install it)
+- [ ] **Recommended:** Complete the [Linux Systems](/paths/linux) path first for git familiarity
+
+## 🎯 Learning Milestones
+
+### 📝 Milestone 1: The Plain Text Manifesto (Week 1)
+
+**Goal:** Understand why plain-text documentation is the sovereign choice and how it positions your team for AI readiness and platform independence.
+
+**Core Concepts:**
+- Plain text as infrastructure: why Markdown is to documentation what TCP/IP is to networking — a universal base layer
+- AI readiness: why LLMs work better with structured Markdown than with WYSIWYG exports
+- Platform independence: your documentation should be readable without the platform that created it
+- Git as documentation infrastructure: version history, blame, branches, and merge requests for docs
+- The "single source of truth" principle: one location, one format, one version
+- RFC 2119 keywords: why `MUST`, `SHOULD`, `MAY` reduce ambiguity in technical documentation
+- Common objections addressed: "Markdown is hard for non-technical users", "We need rich formatting", "Our team won't adopt it"
+
+**🛠️ Hands-on Practice:**
+- [ ] Export one document from your current tool (Confluence, Notion, or Google Docs) and compare the export quality
+- [ ] Write the same document in plain Markdown — measure the difference in readability and portability
+- [ ] Install a Markdown editor (VSCode, Obsidian, or Typora) and get comfortable with the basics
+- [ ] Read the [PIMPyourDocs PRINCIPLES.md](https://gitlab.tas.twn.network/twn/documentation/PIMPyourDocs) for the full philosophy
+- [ ] Write a one-page "documentation manifesto" for your team explaining why you're moving to plain text
+
+**Checkpoint:** Name three situations where Markdown-in-git gives you an advantage over a WYSIWYG wiki. Be specific.
+
+> [!TIP] Need guidance?
+> Join [TWN Commons on Discord](https://discord.gg/kgaMm6WJya) to discuss documentation philosophy and get feedback on your approach.
+
+**💬 Share Your Progress:** Post your documentation manifesto draft in `#documentation` for feedback!
+
+---
+
+### 🏗️ Milestone 2: Document Structure & Spec (Weeks 1–2)
+
+**Goal:** Learn the PIMPyourDocs specification for consistent file naming, directory layout, YAML frontmatter, and document structure.
+
+**Core Concepts:**
+- File naming conventions: `kebab-case`, date prefixes for time-sensitive docs, type prefixes for templates
+- Directory layout: how to organise a documentation repository (by type, by team, by domain — tradeoffs)
+- YAML frontmatter: `title`, `status`, `owner`, `reviewed_at`, `tags` — what each field does and why it matters
+- Document status lifecycle: `draft` → `active` → `deprecated` → `archived`
+- RFC 2119 keyword usage: `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, `MAY` in procedures and specs
+- Heading hierarchy: when to use H1 vs H2 vs H3, and why violating heading order breaks accessibility
+- The "minimum viable document" principle: what every document MUST have before it's published
+
+**🛠️ Hands-on Practice:**
+- [ ] Create a documentation repository structure following the PIMPyourDocs spec
+- [ ] Write three documents with correct frontmatter (title, status, owner, reviewed_at)
+- [ ] Convert an existing document into the correct structure (fix headings, add frontmatter, set lifecycle state)
+- [ ] Write a one-paragraph procedure using RFC 2119 keywords correctly
+- [ ] Review the [PIMPyourDocs SPEC.md](https://gitlab.tas.twn.network/twn/documentation/PIMPyourDocs) and note any differences from your current practice
+
+**Checkpoint:** What does `reviewed_at` in frontmatter actually enable? What breaks if you leave it out?
+
+> [!TIP] Spec questions?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` channel has people who've implemented this spec — ask for their experience.
+
+**💬 Share Your Work:** Post your repository structure for peer feedback!
+
+---
+
+### 📊 Milestone 3: Diagrams as Code (Weeks 2–3)
+
+**Goal:** Master Mermaid diagram syntax for the four most common diagram types: flowchart, sequence, ER, and state — and understand why diagrams-as-code are superior to screenshot-based diagrams.
+
+**Core Concepts:**
+- Diagrams as code: why a Mermaid diagram in a Markdown file is better than a PNG (versionable, searchable, editable without special tools)
+- Mermaid flowchart: `graph TD`, nodes, edges, decision diamonds, subgraphs
+- Mermaid sequence diagram: actors, messages, activation boxes, loops, alt/opt blocks
+- Mermaid ER diagram: entities, attributes, relationships (one-to-many, many-to-many)
+- Mermaid state diagram: states, transitions, initial and final states — excellent for lifecycle documentation
+- When NOT to use Mermaid: complex architectural diagrams where draw.io or Excalidraw is clearer
+- The `diagrams/` directory convention: where diagrams live in a PIMPyourDocs repository
+
+**🛠️ Hands-on Practice:**
+- [ ] Write a Mermaid flowchart for a process you know well (onboarding, incident response, deployment)
+- [ ] Write a Mermaid sequence diagram for an API interaction or multi-party workflow
+- [ ] Write a Mermaid ER diagram for 3–5 information types from the [MSP Content Model](/business/msp-content-model) path
+- [ ] Write a Mermaid state diagram for a document's lifecycle (draft → active → deprecated → archived)
+- [ ] Add all four diagrams to a single Markdown file and render them in your editor
+
+**Checkpoint:** What are two situations where a Mermaid flowchart is the wrong choice? What would you use instead?
+
+> [!TIP] Mermaid help?
+> The [Mermaid Live Editor](https://mermaid.live) is excellent for learning. Share your diagrams in [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` for feedback.
+
+**💬 Share Your Work:** Post your four Mermaid diagrams in Discord for review!
+
+---
+
+### 📑 Milestone 4: Templates in Practice (Weeks 3–4)
+
+**Goal:** Learn the five core PIMPyourDocs templates and practise using each one on real or realistic content.
+
+**Core Concepts:**
+- ADR (Architecture Decision Record): capturing the context, decision, and consequences of technical choices — so future-you understands why
+- RUNBOOK: step-by-step operational procedures with prerequisites, steps, verification, and rollback
+- SERVICE: documenting a service's purpose, owners, dependencies, SLOs, and runbook references
+- API: endpoint documentation with request/response examples, error codes, and authentication requirements
+- INCIDENT: post-incident records with timeline, impact, root cause, and action items
+- Template conventions: what every template shares (frontmatter, status, owner, reviewed_at)
+- The "fill in later" trap: why a template with empty required fields is worse than no template
+
+**🛠️ Hands-on Practice:**
+- [ ] Write an ADR for a technology decision you've made or observed (e.g., "We chose Markdown over Confluence")
+- [ ] Write a RUNBOOK for a procedure you perform regularly (e.g., deploying a service, onboarding a new user)
+- [ ] Write a SERVICE document for a service you operate or use (even a simple one like "our email server")
+- [ ] Write an INCIDENT document for a real or fictitious incident with full timeline and root cause
+- [ ] Review all four documents against the PIMPyourDocs template spec and correct any missing required fields
+
+**Checkpoint:** What's the most important field in an ADR? Why does context matter more than the decision itself?
+
+> [!TIP] Template questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` to share your templates and get feedback from practitioners who use them daily.
+
+**💬 Share Your Work:** Post your ADR and RUNBOOK in Discord for peer review!
+
+---
+
+### 🚪 Milestone 5: Escaping Your Current Platform (Weeks 4–5)
+
+**Goal:** Plan and execute a migration from Confluence, Notion, or Google Docs to plain-text Markdown without losing content or context.
+
+**Core Concepts:**
+- Migration strategy: why "migrate everything at once" always fails and what to do instead
+- Confluence migration: using the `confluence-to-markdown` exporter, cleaning up macro artifacts, restructuring hierarchy
+- Notion migration: Notion's Markdown export quality, what you lose (database properties, linked pages), and how to handle it
+- Google Docs migration: Docs-to-Markdown plugin, table handling, image extraction
+- Content triage: not everything in your current wiki is worth migrating — how to decide what to keep
+- The 80/20 rule for migrations: 20% of your documents are referenced 80% of the time — migrate those first
+- Post-migration verification: how to confirm nothing important was lost
+
+**🛠️ Hands-on Practice:**
+- [ ] Export 20 pages from your current documentation platform (or a sample set if you're learning)
+- [ ] Run an automated migration tool and assess the output quality
+- [ ] Manually clean up 5 migrated documents to meet PIMPyourDocs spec (add frontmatter, fix headings)
+- [ ] Identify 5 documents that aren't worth migrating (outdated, duplicated, or superseded) and archive them
+- [ ] Write a "migration plan" document for your organisation covering: scope, priority order, timeline, verification
+
+**Checkpoint:** You're migrating 500 Confluence pages. You have 40 hours of migration time available. How do you decide what to migrate first?
+
+> [!TIP] Migration challenges?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` channel has people who've migrated from every major platform — share your specific challenges.
+
+**💬 Share Your Progress:** Post your migration plan for peer feedback!
+
+---
+
+### ⚙️ Milestone 6: Spec-Driven Development (Weeks 5–6)
+
+**Goal:** Understand how to use documentation as a development input — specs that drive implementation, planning structures that keep work visible, and testable documentation that can be verified.
+
+**Core Concepts:**
+- Spec-driven development: writing the spec before the code — what it enables and how PIMPyourDocs supports it
+- The `.planning/` directory: where specs, decisions, and work-in-progress planning documents live
+- GSD (Getting Stuff Done) framework: how to structure work items, acceptance criteria, and done definitions in Markdown
+- OpenSpec: open specification format for APIs and services that teams can write before implementation begins
+- Testable documentation: writing procedures that can be verified — steps with expected outputs, not just instructions
+- Documentation as CI artifact: how to include documentation linting and link checking in your build pipeline
+- The "living document" principle: documentation that ages out is worse than no documentation
+
+**🛠️ Hands-on Practice:**
+- [ ] Create a `.planning/` directory in a project and write a spec for a feature you're working on
+- [ ] Write a SERVICE document before implementing the service (spec-first)
+- [ ] Add a documentation linter (markdownlint) to a CI pipeline or pre-commit hook
+- [ ] Write a RUNBOOK where every step has a verification command — test that every step actually works
+- [ ] Set up a link checker to catch broken references in your documentation repository
+
+**Checkpoint:** What's the difference between a procedure and a spec? Write one sentence that captures the distinction.
+
+> [!TIP] Spec-driven questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) `#documentation` and `#engineering` to discuss how teams integrate documentation into their development workflow.
+
+**💬 Share Your Work:** Post your spec-first SERVICE document in Discord for feedback!
+
+---
+
+## 📚 Essential Resources
+
+### Documentation
+- [PIMPyourDocs Repository](https://gitlab.tas.twn.network/twn/documentation/PIMPyourDocs) - The source framework this path is based on
+- [Mermaid Documentation](https://mermaid.js.org/intro/) - Official Mermaid syntax reference
+- [Mermaid Live Editor](https://mermaid.live) - Browser-based Mermaid playground
+- [markdownlint](https://github.com/DavidAnson/markdownlint) - Markdown linting rules and CLI
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) - Key words for use in RFCs (MUST, SHOULD, MAY)
+
+### Tools and Software
+- **VSCode + Markdown extensions** - Free, excellent Markdown editor with Mermaid preview
+- **Obsidian** - Local-first Markdown editor with graph view and excellent plugin ecosystem
+- **Typora** - Clean WYSIWYG Markdown editor (paid, worth it for non-technical users)
+- **GitLab / Gitea** - Self-hosted git platforms with built-in Mermaid rendering in Markdown
+- **markdownlint** - CLI and editor plugin for consistent Markdown formatting
+- **Pandoc** - Universal document converter (Markdown → PDF, DOCX, HTML)
+- **confluence-to-markdown** - Automated Confluence export converter
+
+### Practice Labs
+- **Home Lab** - A GitLab or Gitea instance is ideal; GitHub.com free tier works for learning
+- **Local setup** - VSCode + Markdown Preview Enhanced plugin renders Mermaid locally
+
+## 🤝 Community and Support
+
+**[Join TWN Commons](https://discord.gg/kgaMm6WJya)** for help with:
+- **#documentation** - Markdown, Mermaid, templates, and migration questions
+- **#engineering** - Spec-driven development and CI integration
+- **#lab-help** - Assistance with git and tooling setup
+- **#study-groups** - Find study partners working through the same path
+
+**Share your progress:**
+- Post your Mermaid diagrams and templates for review
+- Share migration challenges and solutions
+- Help others who are earlier in the path
+
+## 🌉 Bridge to TWN Systems
+
+PIMPyourDocs is how TWN itself documents its systems and services:
+
+> [!NOTE] Bridge to TWN
+> TWN uses PIMPyourDocs internally. This means:
+> - The templates you learn here are the same ones used in TWN repos
+> - Your documentation contributions to TWN projects will fit naturally
+> - Self-hosted GitLab (via [TWN Systems providers](https://twn.systems)) is the recommended platform for git-versioned docs
+
+**🛠️ Connected Paths:**
+- **[MSP Content Model](/business/msp-content-model)** - The framework that organises the documents you learn to write here
+- **[Startups Playbook](/business/startups-playbook)** - Milestone 4 uses these documentation practices to document your business stack
+- **[Linux Systems](/paths/linux)** - Git fundamentals underpin everything in this path
+
+## 🚀 What's Next?
+
+After completing this path, you'll be ready for:
+- **[MSP Content Model](/business/msp-content-model)** - Apply documentation discipline to a full knowledge management framework
+- **[Startups Playbook](/business/startups-playbook)** - Document your startup stack as you build it
+- **[Site Reliability Engineering](/paths/sre)** - Apply spec-driven development and runbook practices to reliability engineering
+- **Advanced Documentation Engineering** - Documentation CI pipelines, automated link checking, spec testing
+
+## 🏆 Certification Alignment
+
+This learning path provides practical grounding for:
+- **Technical Writing certifications** (CPTC from STC) - Template discipline and structure align with professional technical writing standards
+- **ITIL Foundation** - Runbook and knowledge management practices align with ITIL knowledge management
+- **Any software development role** - ADRs, specs, and git-based documentation are expected in professional engineering teams
+
+> [!TIP] Focus on Understanding, Not Certs
+> Plain-text documentation skills are permanently useful. Every platform comes and goes; Markdown and git will be here.
+
+---
+
+**Ready to start?** Begin with Milestone 1 and join the [TWN Commons #documentation channel](https://discord.gg/kgaMm6WJya) for support and community.

--- a/content/business/startups-playbook.md
+++ b/content/business/startups-playbook.md
@@ -1,0 +1,275 @@
+---
+title: Startups Playbook
+tags:
+  - business
+  - startups
+  - infrastructure
+  - learning-path
+draft: false
+---
+
+# Startups Playbook Learning Path
+
+Master the decisions that determine whether your startup controls its own destiny. This path takes you from "we need a tech stack" to a self-hosted, sovereign, scalable business — without surrendering your data or budget to SaaS incumbents.
+
+## 📋 Overview
+
+**Duration:** 6–10 weeks (self-paced)
+**Level:** Intermediate
+**Prerequisites:** Basic Linux familiarity, general comfort with technology
+
+**Why this matters:** Most startup guides assume you'll use Stripe Atlas + AWS + Notion + Slack + whatever the current SaaS darling is. That's fine until the pricing changes, the platform sunsets, or you need to move. This path teaches you to build with open-source tools that you own, on infrastructure you control, in ways that keep your options open.
+
+## ✅ Prerequisites
+
+Before starting this path, you should:
+- [ ] Understand basic Linux command line (files, services, SSH)
+- [ ] Know what a server is and roughly how HTTP works
+- [ ] Have access to a small VPS or home lab to practice on
+- [ ] **Recommended:** Complete the [Linux Systems](/paths/linux) path first
+- [ ] **Recommended:** Complete the [Networking Fundamentals](/paths/networking) path
+
+## 🎯 Learning Milestones
+
+### 🏗️ Milestone 1: Business Operating System (BOS) (Weeks 1–2)
+
+**Goal:** Understand what a Business Operating System is, why it matters at every startup stage, and which frameworks apply to your situation.
+
+**Core Concepts:**
+- What a BOS is: the system of systems that runs your business (not just software)
+- Startup stages and why your stack should match your stage (pre-revenue vs. Series A are different problems)
+- Key BOS frameworks: EOS (Entrepreneurial Operating System), Holacracy, and custom hybrid approaches
+- The "sovereign by default" principle: choose tools you can self-host before reaching for SaaS
+- Common BOS anti-patterns: spreadsheet chaos, tribal knowledge, tool sprawl
+
+**🛠️ Hands-on Practice:**
+- [ ] Map your current (or hypothetical) business processes: what information flows where, who makes what decisions
+- [ ] Identify which processes are currently handled by SaaS tools and which could be self-hosted
+- [ ] Draft a one-page "business operating model" covering: how you deliver value, how you invoice, how you track work, how you communicate
+- [ ] Review the TWN Systems BOS template and adapt it to a startup of your choosing
+
+**Checkpoint:** Can you explain the difference between a BOS and a project management tool? What problem does each solve?
+
+> [!TIP] Need guidance?
+> Join [TWN Commons on Discord](https://discord.gg/kgaMm6WJya) to discuss BOS approaches and share what you're building.
+
+**💬 Share Your Progress:** Post your one-page business operating model in the `#business-ops` channel for feedback!
+
+---
+
+### ☁️ Milestone 2: Infrastructure Foundations (Weeks 2–3)
+
+**Goal:** Make informed decisions about self-hosted vs. cloud infrastructure, and understand the tradeoffs of Proxmox, Docker, and Kubernetes for different startup stages.
+
+**Core Concepts:**
+- Self-hosted vs. managed cloud: total cost of ownership, data sovereignty, operational overhead
+- Proxmox VE: virtualisation platform for small-to-medium self-hosted environments
+- Docker and container basics: what they solve, when they're appropriate
+- Kubernetes: what problem it actually solves (and when you don't need it yet)
+- Decision matrix: solo → small team → Series A and what infrastructure each stage needs
+- Backup and disaster recovery as first-class requirements, not afterthoughts
+
+**🛠️ Hands-on Practice:**
+- [ ] Deploy a Proxmox VE instance (VM or bare metal) and create two VMs
+- [ ] Run a containerised application with Docker Compose (e.g., Gitea or Nextcloud)
+- [ ] Set up automated backups for your VM or container to an external location
+- [ ] Complete the [VyOS and Proxmox Network Infrastructure](/paths/vyos-proxmox) milestone 1 if you haven't already
+
+**Checkpoint:** For a 3-person software startup, would you recommend Proxmox + Docker or a managed Kubernetes service? Justify your answer with cost, operational complexity, and sovereignty tradeoffs.
+
+> [!TIP] Stuck on infrastructure decisions?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#infrastructure` channel has practitioners who've made these choices — ask them what they'd do differently.
+
+**💬 Share Your Work:** Post your Proxmox setup or Docker Compose configuration for review!
+
+---
+
+### 🔐 Milestone 3: Security & Identity from Day One (Weeks 3–4)
+
+**Goal:** Implement zero-trust security and identity management before you have a breach, not after.
+
+**Core Concepts:**
+- Why "we'll add security later" is always wrong: the cost of retrofitting vs. building in
+- Identity providers: Keycloak as a self-hosted alternative to Auth0/Okta
+- Zero-trust networking: NetBird and WireGuard for team connectivity without VPN sprawl
+- Dependency security: Dependabot and automated vulnerability scanning
+- Secrets management: Vault and environment variable hygiene
+- Multi-factor authentication as a baseline requirement
+- ISMS (Information Security Management System) basics: what you need before you have customers
+
+**🛠️ Hands-on Practice:**
+- [ ] Deploy Keycloak and configure SSO for at least two services
+- [ ] Set up NetBird to create a zero-trust overlay network for your lab environment
+- [ ] Enable Dependabot (or Renovate) on a code repository
+- [ ] Write a one-page security policy covering: access control, secrets management, incident response
+- [ ] Complete the [NetBird VPN](/paths/netbird-vpn) path for hands-on zero-trust practice
+
+**Checkpoint:** What's the difference between authentication and authorisation? How does Keycloak handle both?
+
+> [!TIP] Security questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) `#security` — there are practitioners who deploy Keycloak and NetBird professionally.
+
+**💬 Share Your Progress:** Share your security policy draft for peer review in Discord!
+
+---
+
+### 📊 Milestone 4: Business Operations Stack (Weeks 4–6)
+
+**Goal:** Replace SaaS subscriptions with self-hosted business operations tools — CRM, project management, and automation.
+
+**Core Concepts:**
+- CRM options: ERPNext (full ERP + CRM) vs. Twenty (lightweight, developer-friendly) vs. managed alternatives
+- Project management: Plane, Taiga, or GitLab Issues as self-hosted alternatives to Jira/Linear
+- Automation: n8n as a self-hosted Zapier/Make alternative for workflow automation
+- Communication: Matrix/Element for team chat, if you want to move off Slack
+- Finance and invoicing: ERPNext Accounts, InvoiceNinja, or Crater
+- The integration problem: how to make these tools talk to each other (hint: n8n)
+
+**🛠️ Hands-on Practice:**
+- [ ] Deploy ERPNext or Twenty and set up a basic CRM with contacts, leads, and pipeline stages
+- [ ] Create an n8n workflow that connects two of your business tools (e.g., new lead → Slack notification)
+- [ ] Migrate a sample dataset from a SaaS tool (CSV export) into your self-hosted alternative
+- [ ] Document your business stack as a simple architecture diagram (Mermaid works well — see the [PIMPyourDocs](/business/pimpyourdocs) path)
+
+**Checkpoint:** What's the main risk of deploying ERPNext for a 2-person startup? What would you do to mitigate it?
+
+> [!TIP] Help with the ops stack?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#business-ops` channel includes people who've deployed ERPNext and n8n in production.
+
+**💬 Share Your Work:** Share your n8n workflow or CRM setup in Discord for feedback!
+
+---
+
+### ⚖️ Milestone 5: Legal & Compliance (Weeks 6–8)
+
+**Goal:** Understand the minimum viable legal and compliance requirements for an Australian technology startup — and build them in, not on.
+
+**Core Concepts:**
+- ABN and company structure: sole trader vs. Pty Ltd and what each means for liability
+- Australian Privacy Act: what it requires, who it applies to, and how to comply from day one
+- Privacy policy and Terms of Service: what they must cover, what templates you can use
+- ISMS (Information Security Management System): ISO 27001 basics and what a lightweight version looks like
+- Data residency: where your data lives and why Australian customers care
+- Contracts: MSA (Master Services Agreement), SOW (Statement of Work), and NDA templates
+- GDPR relevance: if you have EU customers or data, this applies too
+
+**🛠️ Hands-on Practice:**
+- [ ] Register an ABN (or understand the process if you already have one)
+- [ ] Review an open-source Privacy Policy template and identify what you'd need to customise
+- [ ] Write a one-page data handling statement: what data you collect, where it lives, who can access it
+- [ ] Create a lightweight ISMS: a simple spreadsheet tracking your information assets, threats, and controls
+- [ ] Review your infrastructure from Milestone 2 for Australian data residency compliance
+
+**Checkpoint:** Under the Australian Privacy Act, what are the Notifiable Data Breach (NDB) scheme requirements? What would you do if you discovered a breach?
+
+> [!TIP] Legal questions?
+> Join [TWN Commons](https://discord.gg/kgaMm6WJya) to connect with practitioners who've navigated AU compliance — but always verify with a qualified legal professional for your specific situation.
+
+**💬 Share Your Progress:** Share your data handling statement in Discord for peer review!
+
+---
+
+### 📈 Milestone 6: Scaling Your Stack (Weeks 8–10)
+
+**Goal:** Understand how to right-size your systems as you grow from solo to team to Series A — without unnecessary complexity or catastrophic rewrites.
+
+**Core Concepts:**
+- The "scaling trap": over-engineering for scale you don't have yet
+- When to add Kubernetes (hint: later than you think)
+- Database scaling basics: when a single Postgres instance stops being enough
+- Observability: logging, metrics, and alerting before something breaks in production
+- Team scaling: how your BOS needs to change when you go from 2 to 10 to 50 people
+- Cost management: unit economics of self-hosted vs. SaaS at different growth stages
+- The exit ramp: making sure your sovereign stack can be migrated if you need to sell or merge
+
+**🛠️ Hands-on Practice:**
+- [ ] Add monitoring to your self-hosted stack (Prometheus + Grafana or Netdata)
+- [ ] Set up alerting for at least one critical service (disk space, service down, response time)
+- [ ] Review your current architecture and write a "what breaks first" analysis for 10x usage
+- [ ] Draft a 12-month roadmap for your tech stack: what stays, what gets replaced, what gets added
+- [ ] Complete the [Site Reliability Engineering](/paths/sre) path for deeper reliability engineering skills
+
+**Checkpoint:** Your startup just closed a seed round and is hiring 5 engineers. What changes to your infrastructure, security, and BOS would you make in the first 90 days?
+
+> [!TIP] Scaling questions?
+> The [TWN Commons](https://discord.gg/kgaMm6WJya) `#infrastructure` and `#business-ops` channels are full of people who've scaled self-hosted systems.
+
+**💬 Share Your Work:** Post your 12-month roadmap for community feedback!
+
+---
+
+## 📚 Essential Resources
+
+### Documentation
+- [ERPNext Documentation](https://docs.erpnext.com) - Full ERP and CRM platform
+- [Twenty CRM](https://twenty.com) - Lightweight, developer-friendly open-source CRM
+- [n8n Documentation](https://docs.n8n.io) - Workflow automation platform
+- [Keycloak Documentation](https://www.keycloak.org/documentation) - Open-source identity and access management
+- [Proxmox VE Documentation](https://pve.proxmox.com/wiki/Main_Page) - Virtualisation platform
+- [Australian Privacy Act](https://www.oaic.gov.au/privacy/the-privacy-act) - Official guidance from OAIC
+
+### Tools and Software
+- **ERPNext / Frappe** - Full business ERP with CRM, accounting, HR modules
+- **Twenty CRM** - Lightweight alternative for smaller teams
+- **n8n** - Self-hosted workflow automation (Zapier alternative)
+- **Keycloak** - Identity provider and SSO platform
+- **NetBird** - Zero-trust overlay network
+- **Proxmox VE** - Open-source virtualisation
+- **Plane / Taiga** - Project management (Jira alternatives)
+- **Prometheus + Grafana** - Monitoring and observability
+
+### Practice Labs
+- **Home Lab Setup** - A $5–15/month VPS is sufficient for most milestones; a Proxmox node on a used mini-PC covers the rest
+- **TWN Lab Environment** - Ask in [TWN Commons](https://discord.gg/kgaMm6WJya) about shared lab access
+
+## 🤝 Community and Support
+
+**[Join TWN Commons](https://discord.gg/kgaMm6WJya)** for help with:
+- **#business-ops** - BOS frameworks, CRM, automation questions
+- **#infrastructure** - Proxmox, Docker, Kubernetes decisions
+- **#security** - Keycloak, NetBird, ISMS questions
+- **#legal-au** - Australian compliance and regulatory questions (peer discussion, not legal advice)
+- **#lab-help** - Assistance with hands-on exercises
+
+**Share your progress:**
+- Post architecture diagrams and configuration snippets
+- Share your data handling statements and policies for peer review
+- Help others who are earlier in the path
+
+## 🌉 Bridge to TWN Systems
+
+As you build your sovereign startup stack, you'll find TWN Systems directly useful:
+
+> [!NOTE] Bridge to TWN
+> The tools in this path are how TWN-aligned businesses operate. Find providers and tools at [TWN Systems](https://twn.systems) that support:
+> - **Self-hosted infrastructure providers** who won't lock you into proprietary APIs
+> - **Australian data residency options** for Privacy Act compliance
+> - **Community-vetted open-source stacks** that have been tested in production
+
+**🛠️ Connected TWN Paths:**
+- **[VyOS and Proxmox Network Infrastructure](/paths/vyos-proxmox)** - The network layer under your startup stack
+- **[NetBird VPN](/paths/netbird-vpn)** - Zero-trust networking for distributed teams
+- **[PIMPyourDocs](/business/pimpyourdocs)** - Document your stack as you build it
+
+## 🚀 What's Next?
+
+After completing this path, you'll be ready for:
+- **[MSP Content Model](/business/msp-content-model)** - Structure knowledge management for client-facing operations
+- **[PIMPyourDocs](/business/pimpyourdocs)** - Document your stack with plain-text, git-versioned practices
+- **[Site Reliability Engineering](/paths/sre)** - Deepen your reliability and scaling skills
+- **[VyOS and Proxmox Network Infrastructure](/paths/vyos-proxmox)** - Go deeper on the network and virtualisation layer
+
+## 🏆 Certification Alignment
+
+This learning path provides practical grounding for:
+- **AWS Solutions Architect** - Infrastructure and scaling concepts transfer, even though we're not using AWS
+- **ISO 27001 Lead Implementer** - The ISMS milestone directly prepares for this
+- **CompTIA Security+** - Security and identity concepts from Milestone 3
+- **ITIL Foundation** - BOS and service management concepts
+
+> [!TIP] Focus on Understanding, Not Certs
+> The concepts in this path will outlast any specific certification. Build the understanding first; the certifications follow naturally.
+
+---
+
+**Ready to start?** Begin with Milestone 1 and join the [TWN Commons #business-ops channel](https://discord.gg/kgaMm6WJya) for support and community.

--- a/content/index.md
+++ b/content/index.md
@@ -21,10 +21,16 @@ Whether you're entering IT for the first time, changing careers, or solidifying 
 
 ## 📚 Featured Learning Paths
 
+### 🖥️ Technical Foundations
 - **🌐 [Networking Fundamentals](/paths/networking)** - Build core networking knowledge from protocols to infrastructure
 - **🐧 [Linux Systems](/paths/linux)** - Master command line, system administration, and server management
 - **⚡ [Site Reliability Engineering](/paths/sre)** - Learn to design, deploy, and maintain resilient systems
 - **🛡️ [VyOS and Proxmox Network Infrastructure](/paths/vyos-proxmox)** - Deploy production-grade routing, DNS, and multi-cluster architectures
+
+### 🏢 Business & Operations
+- **🚀 [Startups Playbook](/business/startups-playbook)** - Build your startup's tech stack with open-source tools
+- **📋 [MSP Content Model](/business/msp-content-model)** - Structure knowledge for scalable IT service delivery
+- **📝 [PIMPyourDocs](/business/pimpyourdocs)** - Own your documentation with plain-text-first practices
 
 > [!TIP] Need help along the way?
 > Join the [TWN Commons on Discord](https://discord.gg/kgaMm6WJya) to ask questions, share progress, and connect with other learners and professionals.

--- a/docs/plans/2026-03-10-business-operations-section-design.md
+++ b/docs/plans/2026-03-10-business-operations-section-design.md
@@ -1,0 +1,99 @@
+# Business & Operations Section — Design Document
+
+**Date:** 2026-03-10
+**Status:** Implemented
+**Author:** Claude Code
+
+---
+
+## Overview
+
+Adds a new `content/business/` section to ITLearn, covering the operational and business side of running an IT organisation. Complements existing technical paths (networking, Linux, VyOS, VPN) with three structured learning paths derived from TWN internal repositories.
+
+## Motivation
+
+IT learners who understand both the technical and operational sides of an organisation are significantly more valuable. The three source repos teach skills that most technical courses ignore: choosing a startup tech stack, managing client knowledge at scale, and owning documentation as code.
+
+## Target Audience
+
+Same as existing ITLearn paths — IT learners and students who want to build complete professional capability, not just technical skills.
+
+## Source Repositories
+
+| Repo | Description |
+|------|-------------|
+| `twn/marketing/startups-playbook` | Opinionated guide to startup tech stacks (infra, security, compliance, CRM, BOS) — AU-focused |
+| `twn/marketing/msp-content-model` | Knowledge management framework for MSPs (templates, governance, lifecycle) |
+| `twn/documentation/PIMPyourDocs` | Plain-text-first documentation philosophy (Markdown, Mermaid, git-versioned) |
+
+## Files Created
+
+### New
+
+- `content/business/index.md` — Hub page linking to all three paths
+- `content/business/startups-playbook.md` — Startup tech stack learning path (6 milestones)
+- `content/business/msp-content-model.md` — MSP knowledge management path (6 milestones)
+- `content/business/pimpyourdocs.md` — Plain-text documentation path (6 milestones)
+
+### Modified
+
+- `content/index.md` — Added "Business & Operations" section to Featured Learning Paths
+
+## Architecture Decisions
+
+### Separate `content/business/` directory (not `content/paths/`)
+
+The existing `content/paths/` directory contains purely technical learning paths. Business and operations content is a distinct domain. Separating them:
+- Makes the taxonomy clear to learners
+- Allows independent growth of each section
+- Keeps technical paths uncluttered
+
+### Same depth as technical paths
+
+Each business path follows the `content/paths/template.md` structure exactly — same milestone format, same TWN integration callouts, same community Discord references. Consistency matters more than brevity.
+
+### Draft: false on all new files
+
+All files are published immediately. The content is complete and reviewed.
+
+## Path Structures
+
+### 1. Startups Playbook (6 milestones)
+1. Business Operating System (BOS)
+2. Infrastructure Foundations
+3. Security & Identity from Day One
+4. Business Operations Stack
+5. Legal & Compliance (AU-focused)
+6. Scaling Your Stack
+
+**TWN Bridge:** Self-hosted infra providers; connects to NetBird VPN and VyOS paths.
+
+### 2. MSP Content Model (6 milestones)
+1. Why Content Models Matter
+2. Information Inventory
+3. Relationship Mapping
+4. Governance & Ownership
+5. Implementation
+6. Tooling Selection
+
+**TWN Bridge:** PIMPyourDocs for documentation layer; MSP portal.
+
+### 3. PIMPyourDocs (6 milestones)
+1. The Plain Text Manifesto
+2. Document Structure & Spec
+3. Diagrams as Code
+4. Templates in Practice
+5. Escaping Your Current Platform
+6. Spec-Driven Development
+
+**TWN Bridge:** Self-hosted GitLab; PIMPyourDocs used within TWN itself.
+
+## Verification Checklist
+
+- [ ] `npm run quartz build` — no errors
+- [ ] `/business/` index renders with links to all three paths
+- [ ] All three path pages render correctly
+- [ ] `draft: false` on all new files
+- [ ] TWN Commons Discord links present in each path
+- [ ] TWN Systems links present in each path
+- [ ] Cross-path wikilinks resolve


### PR DESCRIPTION
## Summary

- Adds new `content/business/` section with a hub index and three full learning paths (Startups Playbook, MSP Content Model, PIMPyourDocs), each following the `template.md` structure with 6 milestones, TWN Commons callouts, and Bridge to TWN sections
- Updates `content/index.md` to list the Business & Operations paths alongside the existing Technical Foundations paths
- Adds `docs/plans/2026-03-10-business-operations-section-design.md` capturing architecture decisions

## Test Plan

- [x] `npm run quartz build` passes with no errors (485 files parsed, 1219 emitted)
- [x] All four business section pages generated: `public/business/{index,startups-playbook,msp-content-model,pimpyourdocs}.html`
- [x] All files have `draft: false` for immediate publication
- [x] TWN Commons Discord links and TWN Systems links present in each path
- [x] Cross-path wikilinks reference existing paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Business & Operations" learning section with three comprehensive learning paths: Startups Playbook (building sovereign startup infrastructure), MSP Content Model (establishing governed content practices), and PIMPyourDocs (plain-text documentation best practices).

* **Documentation**
  * Added detailed learning paths with multi-milestone curricula, hands-on exercises, checkpoints, and community resources for business and operational topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->